### PR TITLE
fix: 'user' key from anthropic is about 150 char long and openrouter only accepts up to 128

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1570,6 +1570,10 @@ async def create_message_proxy(
     if anthropic_request.metadata and anthropic_request.metadata.get("user_id"):
         openai_params["user"] = str(anthropic_request.metadata.get("user_id"))
 
+    # openrouter rejects messages with 'user' longer than 128 characters
+    if len(openai_params["user"]) > 128:
+        openai_params["user"] = openai_params["user"][:128]
+
     debug(
         LogRecord(
             LogEvent.OPENAI_REQUEST.value,


### PR DESCRIPTION
Signed-off-by: thiswillbeyourgithub <26625900+thiswillbeyourgithub@users.noreply.github.com>
