### PR TITLE
feat: strip openrouter/ prefix from model name

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1366,26 +1366,29 @@ app = fastapi.FastAPI(
 
 def select_target_model(client_model_name: str, request_id: str) -> str:
     """Selects the target OpenRouter model based on the client's request."""
-    client_model_lower = client_model_name.lower()
     target_model: str
-
-    if "opus" in client_model_lower or "sonnet" in client_model_lower:
-        target_model = settings.big_model_name
-    elif "haiku" in client_model_lower:
-        target_model = settings.small_model_name
+    if client_model_name.startswith("openrouter/"):
+        target_model = client_model_name[len("openrouter/") :]
     else:
-        target_model = settings.small_model_name
-        warning(
-            LogRecord(
-                event=LogEvent.MODEL_SELECTION.value,
-                message=f"Unknown client model '{client_model_name}', defaulting to SMALL model '{target_model}'.",
-                request_id=request_id,
-                data={
-                    "client_model": client_model_name,
-                    "default_target_model": target_model,
-                },
+        client_model_lower = client_model_name.lower()
+
+        if "opus" in client_model_lower or "sonnet" in client_model_lower:
+            target_model = settings.big_model_name
+        elif "haiku" in client_model_lower:
+            target_model = settings.small_model_name
+        else:
+            target_model = settings.small_model_name
+            warning(
+                LogRecord(
+                    event=LogEvent.MODEL_SELECTION.value,
+                    message=f"Unknown client model '{client_model_name}', defaulting to SMALL model '{target_model}'.",
+                    request_id=request_id,
+                    data={
+                        "client_model": client_model_name,
+                        "default_target_model": target_model,
+                    },
+                )
             )
-        )
 
     debug(
         LogRecord(

--- a/src/main.py
+++ b/src/main.py
@@ -55,6 +55,31 @@ class Settings(BaseSettings):
     port: int = 8080
     reload: bool = True
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._validate_required_models()
+
+    def _validate_required_models(self):
+        """Validate that required model settings are configured."""
+        errors = []
+        
+        if not self.big_model_name.strip():
+            errors.append(
+                "BIG_MODEL_NAME is required but not configured. "
+                "Please set the BIG_MODEL_NAME environment variable or add it to your .env file."
+            )
+        
+        if not self.small_model_name.strip():
+            errors.append(
+                "SMALL_MODEL_NAME is required but not configured. "
+                "Please set the SMALL_MODEL_NAME environment variable or add it to your .env file."
+            )
+        
+        if errors:
+            error_message = "\n".join([f"❌ {error}" for error in errors])
+            _error_console.print(f"\n[bold red]Configuration Error:[/bold red]\n{error_message}\n")
+            sys.exit(1)
+
 
 settings = Settings()
 


### PR DESCRIPTION
This allows for more flexible model selection by allowing the user to specify a model with the `openrouter/` prefix, which will be automatically stripped. This is useful for specifying models that are not in the default big/small model rotation.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
