### PR TITLE
Strip Anthropic metadata from the system prompt to allow caching

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from logging.config import dictConfig
 from typing import (Any, AsyncGenerator, Awaitable, Callable, Dict, List,
                     Literal, Optional, Tuple, Union, cast)
+import re
 
 import fastapi
 import openai
@@ -714,6 +715,8 @@ def convert_anthropic_to_openai_messages(
                 )
             )
         system_text_content = "\n".join(system_texts)
+
+    system_text_content = re.sub(r'^x-anthropic-billing-header: .*?; cc_entrypoint=.*?; cch=.*?;\n', '', system_text_content)
 
     if system_text_content:
         openai_messages.append({"role": "system", "content": system_text_content})


### PR DESCRIPTION
The metadata in front of the system prompt contains a parameter that changes with every request, which prevents caching. I've verified that this fix allows caching. See image, one request had full cost and the other two were cached reads:

<img width="927" height="255" alt="image" src="https://github.com/user-attachments/assets/642ab841-f720-42ee-8161-51ec82cd1967" />
